### PR TITLE
Replace StringIO from six with built-in

### DIFF
--- a/signalflowcli/csvflow.py
+++ b/signalflowcli/csvflow.py
@@ -7,7 +7,10 @@ from __future__ import print_function
 
 import csv
 from signalfx import signalflow
-import six
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from StringIO import StringIO
 import sys
 
 from . import utils
@@ -26,7 +29,7 @@ def stream(flow, program, start, stop, resolution, max_delay):
         for automatic.
     """
 
-    buf = six.stringio.StringIO()
+    buf = StringIO()
     writer = csv.writer(buf, dialect=csv.excel, quoting=csv.QUOTE_NONNUMERIC)
 
     def _message(msg):

--- a/signalflowcli/csvflow.py
+++ b/signalflowcli/csvflow.py
@@ -7,11 +7,14 @@ from __future__ import print_function
 
 import csv
 from signalfx import signalflow
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
 import sys
+if sys.version_info > (2,):
+    from io import String()
+else:
+    try:
+        from cStringIO import StringIO
+    except ImportError:
+        from StringIO import StringIO
 
 from . import utils
 


### PR DESCRIPTION
Replace the need for the painful 'six' module and use the built-in Python StringIO methods. Added support for Python 3's io.StringIO but also selecting the faster C-based StringIO from Python 2.x or falling back to the non-C StringIO.